### PR TITLE
Make bestGraphic consider siblings

### DIFF
--- a/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.Graphics.cs
+++ b/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.Graphics.cs
@@ -36,7 +36,7 @@ public partial class AlienPartGenerator
         }
         
         public override bool IsApplicable(BodyAddonPawnWrapper pawn, string part) =>
-            pawn.HasHediffOnPartBelowHealthThreshold(part, this.damage);
+            pawn.IsPartBelowHealthThreshold(part, this.damage);
     }
 
     public class BodyAddonAgeGraphic : GenericBodyAddonGraphic
@@ -68,7 +68,7 @@ public partial class AlienPartGenerator
         }
 
         public override bool IsApplicable(BodyAddonPawnWrapper pawn, string part) =>
-            pawn.CurrentLifeStageDef == this.age;
+            pawn.CurrentLifeStageDefMatches(this.age);
     }
 
     public class BodyAddonHediffGraphic : GenericBodyAddonGraphic

--- a/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.cs
+++ b/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.cs
@@ -9,33 +9,32 @@ namespace AlienRace
 
     public partial class AlienPartGenerator
     {
-        public class BodyAddon: GenericBodyAddonGraphic
+        public class BodyAddon : GenericBodyAddonGraphic
         {
             public string bodyPart;
-            
-            public string defaultOffset = "Center";
-            [Unsaved]
-            public BodyAddonOffsets defaultOffsets;
 
-            public BodyAddonOffsets offsets = new ();
-            public bool linkVariantIndexWithPrevious = false;
-            public float angle = 0f;
-            public bool inFrontOfBody = false;
-            public bool layerInvert = true;
+            public           string           defaultOffset = "Center";
+            [Unsaved] public BodyAddonOffsets defaultOffsets;
+
+            public BodyAddonOffsets offsets                      = new();
+            public bool             linkVariantIndexWithPrevious = false;
+            public float            angle                        = 0f;
+            public bool             inFrontOfBody                = false;
+            public bool             layerInvert                  = true;
 
 
-            public bool drawnOnGround = true;
-            public bool drawnInBed = true;
+            public bool drawnOnGround   = true;
+            public bool drawnInBed      = true;
             public bool drawnDesiccated = true;
-            public bool drawForMale = true;
-            public bool drawForFemale = true;
+            public bool drawForMale     = true;
+            public bool drawForFemale   = true;
 
             public bool alignWithHead = false;
 
-            public Vector2 drawSize = Vector2.one;
-            public Vector2 drawSizePortrait = Vector2.zero;
-            public bool drawRotated = true;
-            public bool scaleWithPawnDrawsize = false;
+            public Vector2 drawSize              = Vector2.one;
+            public Vector2 drawSizePortrait      = Vector2.zero;
+            public bool    drawRotated           = true;
+            public bool    scaleWithPawnDrawsize = false;
 
             private string colorChannel;
 
@@ -48,7 +47,7 @@ namespace AlienRace
             public bool debug = true;
 
             public List<BodyPartGroupDef> hiddenUnderApparelFor = new List<BodyPartGroupDef>();
-            public List<string> hiddenUnderApparelTag = new List<string>();
+            public List<string>           hiddenUnderApparelTag = new List<string>();
 
             public string backstoryRequirement;
             public string bodyTypeRequirement;
@@ -61,103 +60,119 @@ namespace AlienRace
                 pawn.GetGender() == Gender.Female ? this.drawForFemale : this.drawForMale;
 
             private bool VisibleForBodyTypeOf(BodyAddonPawnWrapper pawn) => this.bodyTypeRequirement.NullOrEmpty() ||
-                                                             pawn.HasBodyTypeNamed(this.bodyTypeRequirement);
+                                                                            pawn.HasBodyTypeNamed(this
+                                                                            .bodyTypeRequirement);
 
             private bool VisibleUnderApparelOf(BodyAddonPawnWrapper pawn) =>
-                !pawn.HasApparelGraphics() ||
+                !pawn.HasApparelGraphics()                                                             ||
                 (this.hiddenUnderApparelTag.NullOrEmpty() && this.hiddenUnderApparelFor.NullOrEmpty()) ||
                 !pawn.GetWornApparel().Any(ap => !ap.hatRenderedFrontOfFace &&
-                                                ap.bodyPartGroups.Any(predicate: bpgd => this.hiddenUnderApparelFor.Contains(bpgd)) ||
-                                                ap.tags.Any(s => this.hiddenUnderApparelTag.Contains(s)));
-            
+                                                 ap.bodyPartGroups.Any(predicate: bpgd => this.hiddenUnderApparelFor
+                                                                       .Contains(bpgd)) ||
+                                                 ap.tags.Any(s => this.hiddenUnderApparelTag.Contains(s)));
+
             private bool VisibleForPostureOf(BodyAddonPawnWrapper pawn) =>
                 (pawn.GetPosture() == PawnPosture.Standing || this.drawnOnGround) &&
-                (pawn.VisibleInBed() || this.drawnInBed);
+                (pawn.VisibleInBed()                       || this.drawnInBed);
 
 
             private bool VisibleForBackstoryOf(BodyAddonPawnWrapper pawn) => this.backstoryRequirement.NullOrEmpty() ||
-                                                            pawn.HasBackstory(this.backstoryRequirement);
+                                                                             pawn
+                                                                             .HasBackstory(this.backstoryRequirement);
 
             private bool VisibleForRotStageOf(BodyAddonPawnWrapper pawn) =>
                 this.drawnDesiccated || pawn.GetRotStage() != RotStage.Dessicated;
 
             private bool RequiredBodyPartExistsFor(BodyAddonPawnWrapper pawn) =>
-                this.bodyPart.NullOrEmpty() ||
+                this.bodyPart.NullOrEmpty()          ||
                 pawn.HasNamedBodyPart(this.bodyPart) ||
                 (this.hediffGraphics?.Any(predicate: bahg => bahg.hediff == HediffDefOf.MissingBodyPart) ?? false);
 
             public virtual bool CanDrawAddon(Pawn pawn) => this.CanDrawAddon(new BodyAddonPawnWrapper(pawn));
+
             private bool CanDrawAddon(BodyAddonPawnWrapper pawn) =>
-                this.VisibleUnderApparelOf(pawn) &&
-                this.VisibleForPostureOf(pawn) &&
-                this.VisibleForBackstoryOf(pawn) &&
-                this.VisibleForRotStageOf(pawn) &&
+                this.VisibleUnderApparelOf(pawn)     &&
+                this.VisibleForPostureOf(pawn)       &&
+                this.VisibleForBackstoryOf(pawn)     &&
+                this.VisibleForRotStageOf(pawn)      &&
                 this.RequiredBodyPartExistsFor(pawn) &&
-                this.VisibleForGenderOf(pawn) &&
+                this.VisibleForGenderOf(pawn)        &&
                 this.VisibleForBodyTypeOf(pawn);
 
             public IBodyAddonGraphic GetBestGraphic(BodyAddonPawnWrapper pawn, string part)
             {
-                IBodyAddonGraphic bestGraphic = this;
-                Stack<IEnumerator<IBodyAddonGraphic>> stack = new Stack<IEnumerator<IBodyAddonGraphic>>();
-                stack.Push(this.GetSubGraphics(pawn, part)); // generate list of subgraphics
+                Pair<int, IBodyAddonGraphic>                     bestGraphic = new(0, this);
+                Stack<Pair<int, IEnumerator<IBodyAddonGraphic>>> stack       = new();
+                stack.Push(new Pair<int,
+                               IEnumerator<
+                                   IBodyAddonGraphic>>(1, this.GetSubGraphics(pawn, part))); // generate list of subgraphics
 
                 // Loop through sub trees until we find a deeper match or we run out of alternatives
-                while (stack.Count > 0 && bestGraphic == this)
+                while (stack.Count > 0 && (bestGraphic.Second == this || bestGraphic.First < stack.Peek().First))
                 {
-                    IEnumerator<IBodyAddonGraphic> currentGraphicSet = stack.Pop(); // get the top of the stack  
-                    while (currentGraphicSet.MoveNext()) // exits if iterates through list of subgraphics without advancing
+                    Pair<int, IEnumerator<IBodyAddonGraphic>>
+                        currentGraphicSet = stack.Pop(); // get the top of the stack
+                    while (currentGraphicSet.Second
+                                         .MoveNext()) // exits if iterates through list of subgraphics without advancing
                     {
-                        IBodyAddonGraphic current = currentGraphicSet.Current; //current branch of tree
+                        IBodyAddonGraphic current = currentGraphicSet.Second.Current; //current branch of tree
                         if (!(current?.IsApplicable(pawn, part) ?? false)) continue;
-                        if (current.GetPath() == null)
+                        if (current.GetPath().NullOrEmpty())
                             // add the current layer back to the stack so we can rewind
                             stack.Push(currentGraphicSet);
                         else
                             // Only update best graphic if the current one has a valid path
-                            bestGraphic = current;
+                            bestGraphic = new Pair<int, IBodyAddonGraphic>(currentGraphicSet.First, current);
 
-                        currentGraphicSet = current.GetSubGraphics(pawn, part); //enters next layer/branch
+                        // enters next layer/branch
+                        currentGraphicSet =
+                            new Pair<int, IEnumerator<IBodyAddonGraphic>>(currentGraphicSet.First + 1,
+                                                                          current.GetSubGraphics(pawn, part));
                     }
                 }
-                return bestGraphic;
-            }
 
+                return bestGraphic.Second;
+            }
 
             public virtual Graphic GetPath(Pawn pawn, ref int sharedIndex, int? savedIndex = new int?())
             {
-                IBodyAddonGraphic bestGraphic = this.GetBestGraphic(new BodyAddonPawnWrapper(pawn), this.bodyPart);//finds deepest match
+                IBodyAddonGraphic
+                    bestGraphic =
+                        this.GetBestGraphic(new BodyAddonPawnWrapper(pawn), this.bodyPart); //finds deepest match
 
-                string returnPath = bestGraphic.GetPath() ?? string.Empty;
+                string returnPath      = bestGraphic.GetPath() ?? string.Empty;
                 int    variantCounting = bestGraphic.GetVariantCount();
 
                 if (variantCounting <= 0)
                     variantCounting = 1;
 
                 ExposableValueTuple<Color, Color> channel = pawn.GetComp<AlienComp>().GetChannel(this.ColorChannel);
-                int tv;
+                int                               tv;
 
                 //Log.Message($"{pawn.Name.ToStringFull}\n{channel.first.ToString()} | {pawn.story.hairColor}");
 
-                return !returnPath.NullOrEmpty() ?
-                           GraphicDatabase.Get<Graphic_Multi_RotationFromData>(returnPath += (tv = (savedIndex.HasValue ? (sharedIndex = savedIndex.Value % variantCounting) :
-                                                                                             (this.linkVariantIndexWithPrevious ?
-                                                                                                  sharedIndex % variantCounting :
-                                                                                                  (sharedIndex = Rand.Range(min: 0, variantCounting))))) == 0 ? "" : tv.ToString(),
-                                                              ContentFinder<Texture2D>.Get(returnPath + "_northm", reportFailure: false) == null ? this.ShaderType.Shader : ShaderDatabase.CutoutComplex, //ShaderDatabase.Transparent,
-                                                              this.drawSize * 1.5f,
-                                                              channel.first, channel.second, new GraphicData
-                                                              {
-                                                                  drawRotated = !this.drawRotated
-                                                              }) :
-                           null;
+                return !returnPath.NullOrEmpty()
+                           ? GraphicDatabase
+                           .Get<
+                                   Graphic_Multi_RotationFromData>(returnPath += (tv = (savedIndex.HasValue ? (sharedIndex = savedIndex.Value % variantCounting) : (this.linkVariantIndexWithPrevious ? sharedIndex % variantCounting : (sharedIndex = Rand.Range(min: 0, variantCounting))))) == 0 ? "" : tv.ToString(),
+                                                                   ContentFinder<Texture2D>.Get(returnPath + "_northm",
+                                                                       reportFailure: false) == null
+                                                                       ? this.ShaderType.Shader
+                                                                       : ShaderDatabase
+                                                                       .CutoutComplex, //ShaderDatabase.Transparent,
+                                                                   this.drawSize * 1.5f,
+                                                                   channel.first, channel.second, new GraphicData
+                                                                       {
+                                                                           drawRotated = !this.drawRotated
+                                                                       })
+                           : null;
             }
 
 
             // Top level so always considered applicable
             public override bool IsApplicable(BodyAddonPawnWrapper pawn, string part) => true;
         }
-        
+
         public enum BodyAddonPrioritization : byte
         {
             Severity,

--- a/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.cs
+++ b/Source/AlienRace/AlienRace/AlienPartGenerator.BodyAddon.cs
@@ -61,10 +61,10 @@ namespace AlienRace
                 pawn.GetGender() == Gender.Female ? this.drawForFemale : this.drawForMale;
 
             private bool VisibleForBodyTypeOf(BodyAddonPawnWrapper pawn) => this.bodyTypeRequirement.NullOrEmpty() ||
-                                                             pawn.GetBodyTypeName() == this.bodyTypeRequirement;
+                                                             pawn.HasBodyTypeNamed(this.bodyTypeRequirement);
 
             private bool VisibleUnderApparelOf(BodyAddonPawnWrapper pawn) =>
-                !pawn.HasApparel() ||
+                !pawn.HasApparelGraphics() ||
                 (this.hiddenUnderApparelTag.NullOrEmpty() && this.hiddenUnderApparelFor.NullOrEmpty()) ||
                 !pawn.GetWornApparel().Any(ap => !ap.hatRenderedFrontOfFace &&
                                                 ap.bodyPartGroups.Any(predicate: bpgd => this.hiddenUnderApparelFor.Contains(bpgd)) ||

--- a/Source/AlienRace/AlienRace/BodyAddonSupport/BodyAddonPawnWrapper.cs
+++ b/Source/AlienRace/AlienRace/BodyAddonSupport/BodyAddonPawnWrapper.cs
@@ -5,18 +5,26 @@ using System.Linq;
 using RimWorld;
 using Verse;
 
-public class BodyAddonPawnWrapper//contains addon important information from pawn
+/**
+ * Encapsulates pawn access for the purpose of BodyAddon access.
+ */
+public class BodyAddonPawnWrapper
 {
     private Pawn WrappedPawn { get; set; }
 
     public BodyAddonPawnWrapper(Pawn pawn) => this.WrappedPawn = pawn;
 
-    public BodyAddonPawnWrapper() {}
+    public BodyAddonPawnWrapper()
+    {
+    }
 
     public virtual bool HasBackStoryWithIdentifier(string backstoryId) =>
-        this.WrappedPawn.story.AllBackstories.Any(bs => bs.identifier == backstoryId);//matches pawn backstory with input
+        this.GetBackstories()
+         .Any(bs => bs.identifier == backstoryId); //matches pawn backstory with input
 
-    private bool IsHediffOfDefAndPart(Hediff hediff, HediffDef hediffDef, string part) =>//checks if specific hediff is on given part or no part
+    private static bool
+        IsHediffOfDefAndPart(Hediff hediff, HediffDef hediffDef,
+                             string part) => //checks if specific hediff is on given part or no part
         hediff.def == hediffDef &&
         (hediff.Part == null                         ||
          part.NullOrEmpty()                          ||
@@ -24,39 +32,60 @@ public class BodyAddonPawnWrapper//contains addon important information from paw
          hediff.Part.def.defName             == part);
 
     public virtual IEnumerable<float> SeverityOfHediffsOnPart(HediffDef hediffDef, string part) =>
-        this.WrappedPawn.health.hediffSet.hediffs
+        this.GetHediffList()
          .Where(h => IsHediffOfDefAndPart(h, hediffDef, part))
          .Select(h => h.Severity);
 
-    public virtual bool HasHediffOfDefAndPart(HediffDef hediffDef, string part) => this.WrappedPawn.health.hediffSet
-    .hediffs//generate list of pawn hediffs
-    .Any(h => IsHediffOfDefAndPart(h, hediffDef, part));//compares pawn hediffs to specified hediff def and part
+    public virtual bool HasHediffOfDefAndPart(HediffDef hediffDef, string part) => this
+    .GetHediffList()                                     //get list of pawn hediffs
+    .Any(h => IsHediffOfDefAndPart(h, hediffDef, part)); //compares pawn hediffs to specified hediff def and part
 
-    public virtual LifeStageDef CurrentLifeStageDef => this.WrappedPawn.ageTracker.CurLifeStage;//checks if lifestagedefs match
+    //checks if lifestagedefs match
+    public virtual bool CurrentLifeStageDefMatches(LifeStageDef lifeStageDef) =>
+        this.WrappedPawn.ageTracker?.CurLifeStage?.Equals(lifeStageDef) ?? false;
 
-    public virtual bool HasHediffOnPartBelowHealthThreshold(string part, float healthThreshold)
+    public virtual bool IsPartBelowHealthThreshold(string part, float healthThreshold)
     {
         // look for part where a given hediff has a part matching defined part
-        return this.WrappedPawn.health.hediffSet.hediffs
-                .Where(predicate: h => h.Part != null && (h.Part.untranslatedCustomLabel == part || h.Part.def.defName == part))
-                //check if part health is less than health texture limit, needs to config ascending
-                .Any(h => healthThreshold >= this.WrappedPawn.health.hediffSet.GetPartHealth(h.Part));
+        return this.GetHediffList()
+                .Select(hediff => hediff.Part)
+                .Where(hediffPart => hediffPart != null)
+                .Where(hediffPart => hediffPart.untranslatedCustomLabel == part || hediffPart.def?.defName == part)
+                    //check if part health is less than health texture limit, needs to config ascending
+                .Any(p => healthThreshold >= this.GetHediffSet().GetPartHealth(p));
     }
-    
-    public virtual bool HasApparel() => !WrappedPawn.Drawer.renderer.graphics.apparelGraphics.NullOrEmpty();
 
-    public virtual IEnumerable<ApparelProperties> GetWornApparel() => WrappedPawn.apparel.WornApparel.Select(ap => ap.def.apparel);
-    public virtual bool VisibleInBed() => WrappedPawn.CurrentBed()?.def.building.bed_showSleeperBody ?? true;
+    public virtual bool HasApparelGraphics() =>
+        !this.WrappedPawn.Drawer?.renderer?.graphics?.apparelGraphics?.NullOrEmpty() ?? false;
+
+    public virtual IEnumerable<ApparelProperties> GetWornApparel() =>
+        this.WrappedPawn.apparel?.WornApparel?.Select(ap => ap.def.apparel) ?? Enumerable.Empty<ApparelProperties>();
+
+    public virtual bool VisibleInBed() => this.WrappedPawn.CurrentBed()?.def?.building?.bed_showSleeperBody ?? true;
+
     public virtual bool HasBackstory(string backstoryId) =>
-        WrappedPawn.story.AllBackstories.Any(b => b.identifier == backstoryId);
+        this.WrappedPawn.story?.AllBackstories?.Any(b => b.identifier == backstoryId) ?? false;
 
     public virtual bool HasNamedBodyPart(string part) =>
-        WrappedPawn.health.hediffSet.GetNotMissingParts()
-         .Any(bpr => bpr.untranslatedCustomLabel == part || bpr.def.defName == part);
+        this.GetHediffSet().GetNotMissingParts()
+         ?.Any(bpr => bpr.untranslatedCustomLabel == part || bpr.def.defName == part) ?? false;
 
-    public virtual Gender GetGender() => WrappedPawn.gender;
-    public virtual PawnPosture GetPosture() => WrappedPawn.GetPosture();
-    public virtual string GetBodyTypeName() => WrappedPawn.story.bodyType.ToString();
-    public virtual RotStage? GetRotStage() => WrappedPawn.Corpse?.GetRotStage();
+    public virtual Gender GetGender() => this.WrappedPawn.gender;
 
+    public virtual PawnPosture GetPosture() => this.WrappedPawn.GetPosture();
+
+    public virtual bool HasBodyTypeNamed(string bodyType) =>
+        this.WrappedPawn.story?.bodyType?.ToString().EqualsIgnoreCase(bodyType) ?? false;
+
+    public virtual RotStage? GetRotStage() => this.WrappedPawn.Corpse?.GetRotStage();
+
+    public virtual List<Hediff> GetHediffList() => this.GetHediffSet().hediffs;
+
+    /**
+     * Helper to get a HediffSet or initialise one if absent
+     */
+    public virtual HediffSet GetHediffSet() => this.WrappedPawn.health?.hediffSet ?? new HediffSet(this.WrappedPawn);
+
+    public virtual IEnumerable<Backstory> GetBackstories() =>
+        this.WrappedPawn.story?.AllBackstories ?? Enumerable.Empty<Backstory>();
 }

--- a/Source/AlienRace/AlienRaceTest/AlienRaceTest.csproj
+++ b/Source/AlienRace/AlienRaceTest/AlienRaceTest.csproj
@@ -55,6 +55,7 @@
         </Reference>
     </ItemGroup>
     <ItemGroup>
+        <Compile Include="BodyAddonSupport\BodyAddonPawnWrapperTest.cs" />
         <Compile Include="BodyAddonTest.cs" />
         <Compile Include="BodyAddonXMLTest.cs" />
         <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Source/AlienRace/AlienRaceTest/BodyAddonSupport/BodyAddonPawnWrapperTest.cs
+++ b/Source/AlienRace/AlienRaceTest/BodyAddonSupport/BodyAddonPawnWrapperTest.cs
@@ -1,0 +1,40 @@
+namespace AlienRaceTest.BodyAddonSupport
+{
+    using System.Runtime.Serialization;
+    using AlienRace.BodyAddonSupport;
+    using Moq;
+    using NUnit.Framework;
+    using TestSupport;
+    using Verse;
+
+    [TestFixture]
+    public class BodyAddonPawnWrapperTest : BaseUnityTest
+    {
+        private Pawn                 pawn;
+        private BodyAddonPawnWrapper pawnWrapperUnderTest;
+
+        [SetUp]
+        public void SetupBodyAddonPawnWrapperTest()
+        {
+            this.pawn = new Pawn();
+            Pawn_HealthTracker healthTracker =
+                (Pawn_HealthTracker)FormatterServices
+                .GetUninitializedObject(typeof(Pawn_HealthTracker)); //does not call ctor
+            healthTracker.hediffSet   = new HediffSet(this.pawn);
+            this.pawn.health          = healthTracker;
+            this.pawnWrapperUnderTest = new BodyAddonPawnWrapper(this.pawn);
+        }
+
+        [Test]
+        public void TestHediffsOnPartAreAlwaysFalseForFullBodyHediffs()
+        {
+            Mock<Hediff> fullBodyHediff = new Mock<Hediff>();
+            this.pawn.health.hediffSet.hediffs.Add(fullBodyHediff.Object);
+
+            Assert.IsFalse(this.pawnWrapperUnderTest.IsPartBelowHealthThreshold("leg", 0f));
+            Assert.IsFalse(this.pawnWrapperUnderTest.IsPartBelowHealthThreshold("leg", 1f));
+            Assert.IsFalse(this.pawnWrapperUnderTest.IsPartBelowHealthThreshold("",    1f));
+            Assert.IsFalse(this.pawnWrapperUnderTest.IsPartBelowHealthThreshold(null,  1f));
+        }
+    }
+}

--- a/Source/AlienRace/AlienRaceTest/BodyAddonTest.cs
+++ b/Source/AlienRace/AlienRaceTest/BodyAddonTest.cs
@@ -176,10 +176,10 @@
         {
             AlienPartGenerator.BodyAddon addonUnderTest  = this.GetTestBodyAddon();
             Mock<BodyAddonPawnWrapper>   mockPawnWrapper = new Mock<BodyAddonPawnWrapper>();
-            mockPawnWrapper.SetupGet(p => p.CurrentLifeStageDef).Returns(mockOtherAdultLifestageDef.Object);
+            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockOtherAdultLifestageDef.Object)).Returns(true);
             mockPawnWrapper.Setup(p => p.HasBackStoryWithIdentifier("specificBackstory")).Returns(true);
-            mockPawnWrapper.Setup(p => p.HasHediffOnPartBelowHealthThreshold("nose", 1f)).Returns(false);
-            mockPawnWrapper.Setup(p => p.HasHediffOnPartBelowHealthThreshold("nose", 5f)).Returns(true);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 1f)).Returns(false);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 5f)).Returns(true);
 
             // Resolve
             IBodyAddonGraphic bestGraphic = addonUnderTest.GetBestGraphic(mockPawnWrapper.Object, "nose");
@@ -193,10 +193,10 @@
         {
             AlienPartGenerator.BodyAddon addonUnderTest  = this.GetTestBodyAddon();
             Mock<BodyAddonPawnWrapper>   mockPawnWrapper = new Mock<BodyAddonPawnWrapper>();
-            mockPawnWrapper.SetupGet(p => p.CurrentLifeStageDef).Returns(mockOtherAdultLifestageDef.Object);
+            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockOtherAdultLifestageDef.Object)).Returns(true);
             mockPawnWrapper.Setup(p => p.HasBackStoryWithIdentifier("specificBackstory")).Returns(true);
-            mockPawnWrapper.Setup(p => p.HasHediffOnPartBelowHealthThreshold("nose", 1f)).Returns(false);
-            mockPawnWrapper.Setup(p => p.HasHediffOnPartBelowHealthThreshold("nose", 5f)).Returns(false);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 1f)).Returns(false);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 5f)).Returns(false);
 
             // Resolve
             IBodyAddonGraphic bestGraphic = addonUnderTest.GetBestGraphic(mockPawnWrapper.Object, "nose");
@@ -210,12 +210,12 @@
         {
             AlienPartGenerator.BodyAddon addonUnderTest  = this.GetTestBodyAddon();
             Mock<BodyAddonPawnWrapper>   mockPawnWrapper = new Mock<BodyAddonPawnWrapper>();
-            mockPawnWrapper.SetupGet(p => p.CurrentLifeStageDef).Returns(mockHumanlikeAdultLifestageDef.Object);
+            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockHumanlikeAdultLifestageDef.Object)).Returns(true);
             mockPawnWrapper.Setup(p => p.HasBackStoryWithIdentifier("specificBackstory")).Returns(false);
             mockPawnWrapper.Setup(p => p.HasHediffOfDefAndPart(mockBurnHediff.Object, "nose")).Returns(false);
             mockPawnWrapper.Setup(p => p.HasHediffOfDefAndPart(mockCutHediff.Object,  "nose")).Returns(false);
-            mockPawnWrapper.Setup(p => p.HasHediffOnPartBelowHealthThreshold("nose", 1f)).Returns(false);
-            mockPawnWrapper.Setup(p => p.HasHediffOnPartBelowHealthThreshold("nose", 5f)).Returns(true);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 1f)).Returns(false);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 5f)).Returns(true);
 
             // Resolve
             IBodyAddonGraphic bestGraphic = addonUnderTest.GetBestGraphic(mockPawnWrapper.Object, "nose");
@@ -228,12 +228,12 @@
         {
             AlienPartGenerator.BodyAddon addonUnderTest  = this.GetTestBodyAddon();
             Mock<BodyAddonPawnWrapper>   mockPawnWrapper = new Mock<BodyAddonPawnWrapper>();
-            mockPawnWrapper.SetupGet(p => p.CurrentLifeStageDef).Returns(mockHumanlikeAdultLifestageDef.Object);
+            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockHumanlikeAdultLifestageDef.Object)).Returns(true);
             mockPawnWrapper.Setup(p => p.HasBackStoryWithIdentifier("specificBackstory")).Returns(false);
             mockPawnWrapper.Setup(p => p.HasHediffOfDefAndPart(mockBurnHediff.Object, "nose")).Returns(false);
             mockPawnWrapper.Setup(p => p.HasHediffOfDefAndPart(mockCutHediff.Object,  "nose")).Returns(false);
-            mockPawnWrapper.Setup(p => p.HasHediffOnPartBelowHealthThreshold("nose", 1f)).Returns(false);
-            mockPawnWrapper.Setup(p => p.HasHediffOnPartBelowHealthThreshold("nose", 5f)).Returns(false);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 1f)).Returns(false);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 5f)).Returns(false);
 
             // Resolve
             IBodyAddonGraphic bestGraphic = addonUnderTest.GetBestGraphic(mockPawnWrapper.Object, "nose");

--- a/Source/AlienRace/AlienRaceTest/BodyAddonTest.cs
+++ b/Source/AlienRace/AlienRaceTest/BodyAddonTest.cs
@@ -1,5 +1,6 @@
 ﻿namespace AlienRaceTest
 {
+    using System;
     using System.Collections.Generic;
     using AlienRace;
     using AlienRace.BodyAddonSupport;
@@ -103,7 +104,22 @@
                                                                }
                                                            }
                                       }
-                                  }
+                                  },
+                    damageGraphics = new List<AlienPartGenerator.BodyAddonDamageGraphic>
+                                     {
+                                         new AlienPartGenerator.BodyAddonDamageGraphic
+                                         {
+                                             damage = 1f,
+                                             path =
+                                                 "/backstoryGraphics/specificBackstory/damageGraphics/a1"
+                                         },
+                                         new AlienPartGenerator.BodyAddonDamageGraphic
+                                         {
+                                             damage = 5f,
+                                             path =
+                                                 "/backstoryGraphics/specificBackstory/damageGraphics/a5"
+                                         }
+                                     }
                 };
             AlienPartGenerator.BodyAddonAgeGraphic age = new AlienPartGenerator.BodyAddonAgeGraphic
                                                          {
@@ -176,7 +192,8 @@
         {
             AlienPartGenerator.BodyAddon addonUnderTest  = this.GetTestBodyAddon();
             Mock<BodyAddonPawnWrapper>   mockPawnWrapper = new Mock<BodyAddonPawnWrapper>();
-            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockOtherAdultLifestageDef.Object)).Returns(true);
+            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockOtherAdultLifestageDef.Object))
+                        .Returns(true);
             mockPawnWrapper.Setup(p => p.HasBackStoryWithIdentifier("specificBackstory")).Returns(true);
             mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 1f)).Returns(false);
             mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 5f)).Returns(true);
@@ -193,7 +210,8 @@
         {
             AlienPartGenerator.BodyAddon addonUnderTest  = this.GetTestBodyAddon();
             Mock<BodyAddonPawnWrapper>   mockPawnWrapper = new Mock<BodyAddonPawnWrapper>();
-            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockOtherAdultLifestageDef.Object)).Returns(true);
+            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockOtherAdultLifestageDef.Object))
+                        .Returns(true);
             mockPawnWrapper.Setup(p => p.HasBackStoryWithIdentifier("specificBackstory")).Returns(true);
             mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 1f)).Returns(false);
             mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 5f)).Returns(false);
@@ -210,7 +228,8 @@
         {
             AlienPartGenerator.BodyAddon addonUnderTest  = this.GetTestBodyAddon();
             Mock<BodyAddonPawnWrapper>   mockPawnWrapper = new Mock<BodyAddonPawnWrapper>();
-            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockHumanlikeAdultLifestageDef.Object)).Returns(true);
+            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockHumanlikeAdultLifestageDef.Object))
+                        .Returns(true);
             mockPawnWrapper.Setup(p => p.HasBackStoryWithIdentifier("specificBackstory")).Returns(false);
             mockPawnWrapper.Setup(p => p.HasHediffOfDefAndPart(mockBurnHediff.Object, "nose")).Returns(false);
             mockPawnWrapper.Setup(p => p.HasHediffOfDefAndPart(mockCutHediff.Object,  "nose")).Returns(false);
@@ -228,7 +247,8 @@
         {
             AlienPartGenerator.BodyAddon addonUnderTest  = this.GetTestBodyAddon();
             Mock<BodyAddonPawnWrapper>   mockPawnWrapper = new Mock<BodyAddonPawnWrapper>();
-            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockHumanlikeAdultLifestageDef.Object)).Returns(true);
+            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockHumanlikeAdultLifestageDef.Object))
+                        .Returns(true);
             mockPawnWrapper.Setup(p => p.HasBackStoryWithIdentifier("specificBackstory")).Returns(false);
             mockPawnWrapper.Setup(p => p.HasHediffOfDefAndPart(mockBurnHediff.Object, "nose")).Returns(false);
             mockPawnWrapper.Setup(p => p.HasHediffOfDefAndPart(mockCutHediff.Object,  "nose")).Returns(false);
@@ -239,6 +259,100 @@
             IBodyAddonGraphic bestGraphic = addonUnderTest.GetBestGraphic(mockPawnWrapper.Object, "nose");
 
             Assert.AreEqual("/", bestGraphic.GetPath());
+        }
+
+        [Test]
+        public void TestHandlesTopLevelNullPath()
+        {
+            AlienPartGenerator.BodyAddon addonUnderTest = this.GetTestBodyAddon();
+            addonUnderTest.path = null;
+            Mock<BodyAddonPawnWrapper> mockPawnWrapper = new Mock<BodyAddonPawnWrapper>();
+            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockHumanlikeAdultLifestageDef.Object))
+                        .Returns(true);
+            mockPawnWrapper.Setup(p => p.HasBackStoryWithIdentifier("specificBackstory")).Returns(false);
+            mockPawnWrapper.Setup(p => p.HasHediffOfDefAndPart(mockBurnHediff.Object, "nose")).Returns(false);
+            mockPawnWrapper.Setup(p => p.HasHediffOfDefAndPart(mockCutHediff.Object,  "nose")).Returns(false);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 1f)).Returns(false);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 5f)).Returns(true);
+
+            // Resolve
+            IBodyAddonGraphic bestGraphic = addonUnderTest.GetBestGraphic(mockPawnWrapper.Object, "nose");
+
+            Assert.AreEqual("/damageGraphics/a5", bestGraphic.GetPath());
+        }
+
+        [Test]
+        public void TestFallsBackToParentWhenFindingNull()
+        {
+            AlienPartGenerator.BodyAddon addonUnderTest = this.GetTestBodyAddon();
+            addonUnderTest.backstoryGraphics[0].ageGraphics[0].damageGraphics
+                       .Find(d => Math.Abs(d.damage - 5f) < 0.0001).path = null;
+            Mock<BodyAddonPawnWrapper> mockPawnWrapper = new Mock<BodyAddonPawnWrapper>();
+            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockOtherAdultLifestageDef.Object))
+                        .Returns(true);
+            mockPawnWrapper.Setup(p => p.HasBackStoryWithIdentifier("specificBackstory")).Returns(true);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 1f)).Returns(false);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 5f)).Returns(true);
+
+            // Resolve
+            IBodyAddonGraphic bestGraphic = addonUnderTest.GetBestGraphic(mockPawnWrapper.Object, "nose");
+
+            Assert.AreEqual("/backstoryGraphics/specificBackstory/ageGraphics/otherAdultLifestage",
+                            bestGraphic.GetPath());
+        }
+
+        [Test]
+        public void TestFallsBackToDeeperSiblingMatchOnParentWhenFindingNull()
+        {
+            AlienPartGenerator.BodyAddon addonUnderTest = this.GetTestBodyAddon();
+            addonUnderTest.backstoryGraphics[0].ageGraphics[0].path = null;
+            addonUnderTest.backstoryGraphics[0].ageGraphics[0].damageGraphics
+                       .Find(d => Math.Abs(d.damage - 5f) < 0.0001).path = null;
+            Mock<BodyAddonPawnWrapper> mockPawnWrapper = new Mock<BodyAddonPawnWrapper>();
+            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockOtherAdultLifestageDef.Object))
+                        .Returns(true);
+            mockPawnWrapper.Setup(p => p.HasBackStoryWithIdentifier("specificBackstory")).Returns(true);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 1f)).Returns(false);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 5f)).Returns(true);
+
+            // Resolve
+            IBodyAddonGraphic bestGraphic = addonUnderTest.GetBestGraphic(mockPawnWrapper.Object, "nose");
+
+            Assert.AreEqual("/backstoryGraphics/specificBackstory/damageGraphics/a5",
+                            bestGraphic.GetPath());
+            // Verify that we got to the damage child but then backtracked hence needing to call this again on the top level backstory->damage branch
+            mockPawnWrapper.Verify(p => p.IsPartBelowHealthThreshold("nose", 5f), Times.Exactly(2));
+        }
+
+        [Test]
+        public void TestFallsBackToDeeperSiblingMatchOnParentWhenFindingNullAndParentPathIsNotNull()
+        {
+            AlienPartGenerator.BodyAddon addonUnderTest = this.GetTestBodyAddon();
+            addonUnderTest.backstoryGraphics[0].ageGraphics[0].ageGraphics =
+                new List<AlienPartGenerator.BodyAddonAgeGraphic>
+                {
+                    new AlienPartGenerator.BodyAddonAgeGraphic
+                    {
+                        age = mockOtherAdultLifestageDef.Object,
+                        path = "" //if not null would have been ./ageGraphics/otherAdultLifestage/ageGraphics/otherAdultLifestage
+                    }
+                };
+            Mock<BodyAddonPawnWrapper> mockPawnWrapper = new Mock<BodyAddonPawnWrapper>();
+            mockPawnWrapper.Setup(p => p.CurrentLifeStageDefMatches(this.mockOtherAdultLifestageDef.Object))
+                        .Returns(true);
+            mockPawnWrapper.Setup(p => p.HasBackStoryWithIdentifier("specificBackstory")).Returns(true);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 1f)).Returns(false);
+            mockPawnWrapper.Setup(p => p.IsPartBelowHealthThreshold("nose", 5f)).Returns(true);
+
+            // Resolve
+            IBodyAddonGraphic bestGraphic = addonUnderTest.GetBestGraphic(mockPawnWrapper.Object, "nose");
+
+            Assert.AreEqual("/backstoryGraphics/specificBackstory/ageGraphics/otherAdultLifestage/damageGraphics/a5",
+                            bestGraphic.GetPath());
+
+            // Verify that we hit the extra age branch added above by confirming we descended into 2 age/otherAdultLifestage branches and then picked the sibling
+            mockPawnWrapper.Verify(p => p.CurrentLifeStageDefMatches(this.mockOtherAdultLifestageDef.Object),
+                                   Times.Exactly(2));
         }
     }
 }


### PR DESCRIPTION
Fix for rewinding best graphic stack not considering alternate siblings which may have deeper matches after any non-top-level graphic has been found. Cannot be simplified to just a boolean as we need the level to not rewind all the way back up the tree after finding a null.